### PR TITLE
Remove draft reference from charter work items

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -74,6 +74,7 @@ Documents produced by the working group will include the following:
 
 
 ## Inspiring Input Documents
+
 - SD-CWT - https://datatracker.ietf.org/doc/draft-prorock-cose-sd-cwt/
     - may be used as a starting point for aligning selective disclosure with registered claim names between JWT and CWT.
 - Use case document https://datatracker.ietf.org/doc/draft-prorock-spice-use-cases/ 

--- a/charter.md
+++ b/charter.md
@@ -70,12 +70,12 @@ Documents produced by the working group will include the following:
     - commenting on proof type (signatures, detecting duplicity, non equivocation, unlinkability, redactability)
 - Unlinkabilty of SD/VC with CWTs
 - Selective Disclosure with CWTs
-    - https://datatracker.ietf.org/doc/draft-prorock-cose-sd-cwt/ may be used as a starting point for aligning selective disclosure with registered claim names between JWT and CWT.
 - Identity Document serializations using JWT/CWT 
 
 
 ## Inspiring Input Documents
-
+- SD-CWT - https://datatracker.ietf.org/doc/draft-prorock-cose-sd-cwt/
+    - may be used as a starting point for aligning selective disclosure with registered claim names between JWT and CWT.
 - Use case document https://datatracker.ietf.org/doc/draft-prorock-spice-use-cases/ 
 - Unlinkable Selective Disclosure with JWPs https://datatracker.ietf.org/doc/draft-ietf-jose-json-web-proof/
 - Proofs of Inclusion / Consistency - https://datatracker.ietf.org/doc/draft-ietf-cose-merkle-tree-proofs/


### PR DESCRIPTION
Justin gave this feedback on the call when we reviewed the draft charter together.

I agree with it, there is no sense in triggering an administrative block if it can so easily be avoided.