### PR TITLE
add accountability as a key design property

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -59,7 +59,7 @@ The SPICE WG's work items will not require nor forbid the use of JSON-LD. Retain
 - Availability (efficiently information processing, minimizing data in flight, reducing carbon cost for storage and transmission, and supporting offline / paper credential use cases)
 - Semantic interchangeability (ensuring terms are understood and used consistently, in a global or local context)
 - Usability and Feasibility ( The core operations must be easy to understand and use, and possible to integrate with existing platforms)
-- Accountability (what format and protocol considerations can help mitigates abusive or excessive requests for credential presentation?  what mitigates abuse by issuers?)
+- Accountability (what format and protocol considerations can help mitigate abusive or excessive requests for credential presentation?  What mitigates abuse by issuers?)
 
 ## Work Items
 

--- a/charter.md
+++ b/charter.md
@@ -58,7 +58,7 @@ The SPICE WG's work items will not require nor forbid the use of JSON-LD. Retain
 - Confidentiality (ensuring information is protected from unauthorized access)
 - Availability (efficiently information processing, minimizing data in flight, reducing carbon cost for storage and transmission, and supporting offline / paper credential use cases)
 - Semantic interchangeability (ensuring terms are understood and used consistently, in a global or local context)
-- Usability and Feasibility ( The core operations must be easy to understand and use, and possible to integrate with existing platforms)
+- Usability and Feasibility (the core operations must be easy to understand and use, and possible to integrate with existing platforms)
 - Accountability (what format and protocol considerations can help mitigate abusive or excessive requests for credential presentation?  What mitigates abuse by issuers?)
 
 ## Work Items

--- a/charter.md
+++ b/charter.md
@@ -59,6 +59,7 @@ The SPICE WG's work items will not require nor forbid the use of JSON-LD. Retain
 - Availability (efficiently information processing, minimizing data in flight, reducing carbon cost for storage and transmission, and supporting offline / paper credential use cases)
 - Semantic interchangeability (ensuring terms are understood and used consistently, in a global or local context)
 - Usability and Feasibility ( The core operations must be easy to understand and use, and possible to integrate with existing platforms)
+- Accountability (what format and protocol considerations can help mitigates abusive or excessive requests for credential presentation?  what mitigates abuse by issuers?)
 
 ## Work Items
 


### PR DESCRIPTION
When is a verifier allowed to request a credential?  What hooks do the mechanisms offer to attach consequences to a verifier who requests access to credentials that they do not need?  How can issuers be held accountable?